### PR TITLE
Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM dfam/tetools:latest AS builder
+
+RUN apt update && apt upgrade -y
+
+# Add software to path
+
+
+
+# MCHelper installation
+
+RUN apt install -y git unzip python3-pandas python3-opencv python3-psutil python3-sklearn r-base python3-opencv hmmer emboss
+RUN pip install --break-system-packages pdf2image Bio cialign

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,3 +10,5 @@ RUN apt update && apt upgrade -y
 
 RUN apt install -y git unzip python3-pandas python3-opencv python3-psutil python3-sklearn r-base python3-opencv hmmer emboss
 RUN pip install --break-system-packages pdf2image Bio cialign
+# Add dependencies to path
+ENV PATH="$PATH:/opt/cd-hit:/opt/mafft/bin"

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,12 @@ RUN apt update && apt upgrade -y
 
 
 # MCHelper installation
-
 RUN apt install -y git unzip python3-pandas python3-opencv python3-psutil python3-sklearn r-base python3-opencv hmmer emboss
 RUN pip install --break-system-packages pdf2image Bio cialign
 # Add dependencies to path
 ENV PATH="$PATH:/opt/cd-hit:/opt/mafft/bin"
+
+RUN git clone https://github.com/GonzalezLab/MCHelper /opt/mchelper
+WORKDIR /opt/mchelper
+RUN cd db && unzip '*.zip'
+RUN bash


### PR DESCRIPTION
Add a Dockerfile from TETools and all MCHelper dependencies. It can be built by `docker build -t mchelper .` and executed simply using `docker run -it mchelper`. Tests executed successfully.
If you want to use a folder outside the container, please mount it as a docker volume, the command would be: 
`docker run -it -v /complete/user/data/path:/container/path`